### PR TITLE
Resolve pressed detection when using touch screen [JDK-8193038 bug]

### DIFF
--- a/keyboardfx/pom.xml
+++ b/keyboardfx/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.dlsc.keyboardfx</groupId>
     <artifactId>keyboardfx</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <name>KeyboardFX</name>

--- a/keyboardfx/src/main/java/com/dlsc/keyboardfx/skins/KeyView.java
+++ b/keyboardfx/src/main/java/com/dlsc/keyboardfx/skins/KeyView.java
@@ -35,9 +35,16 @@ public class KeyView extends KeyViewBase<Key> {
         visibleProperty().bind(Bindings.isNotEmpty(vBox.getChildren()));
 
         updateLabels();
+        setOnTouchPressed(touchEvent -> this.setPressed(true));
 
-        setOnMousePressed(this::handlePressed);
-        setOnMouseReleased(this::handleReleased);
+        this.pressedProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue)
+                this.handlePressed();
+            else
+                this.handleReleased();
+        });
+
+        this.pressedProperty().addListener((observableValue, aBoolean, t1) -> System.out.println("pressed " + t1));
     }
 
     public KeyView(KeyboardView keyboardView, Key key, String text) {
@@ -159,7 +166,7 @@ public class KeyView extends KeyViewBase<Key> {
 
     private ShowExtraKeysThread showExtraKeysThread;
 
-    private void handlePressed(MouseEvent evt) {
+    private void handlePressed() {
         if (text == null) {
             if (showExtraKeysThread != null) {
                 showExtraKeysThread.cancel();
@@ -170,7 +177,7 @@ public class KeyView extends KeyViewBase<Key> {
         }
     }
 
-    private void handleReleased(MouseEvent evt) {
+    private void handleReleased() {
         if (showExtraKeysThread != null) {
             showExtraKeysThread.cancel();
         }

--- a/keyboardfx/src/main/java/com/dlsc/keyboardfx/skins/SpecialKeyView.java
+++ b/keyboardfx/src/main/java/com/dlsc/keyboardfx/skins/SpecialKeyView.java
@@ -53,6 +53,7 @@ public class SpecialKeyView extends KeyViewBase<SpecialKey> {
         keyboardView.modeProperty().addListener(it -> updateSelection());
         updateSelection();
 
+        setOnTouchPressed(event -> this.setPressed(true));
         setOnMouseClicked(this::handleClick);
     }
 


### PR DESCRIPTION
Using touch screen to operate keyboard in Windows doesn't set `pressed` property and keyboard key don't change background when touched. Finger must be slightly moved on key to change background and start thread to show extra keys.

https://bugs.openjdk.java.net/browse/JDK-8193038